### PR TITLE
Improve template to disable IPv6 correctly

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: run sysctl
-  command: sysctl -p
+  command: sysctl --load=/etc/sysctl.d/10-disable-ipv6.conf

--- a/templates/disableipv6.conf.template
+++ b/templates/disableipv6.conf.template
@@ -1,3 +1,4 @@
 net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.all.autoconf = 0
 net.ipv6.conf.default.disable_ipv6 = 1
-net.ipv6.conf.lo.disable_ipv6 = 1
+net.ipv6.conf.default.autoconf = 0


### PR DESCRIPTION
- Remove IPv6 autoconf configuration in systctl
- Specific setting for loopback is useless
- Improve handler, `sysctl -p` does seem to reload files in `/etc/sysctl.d`